### PR TITLE
fix bug in mySgemmV3Aligned and remove the argument of -arch and -code in makefie.

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,6 @@
 default:
-	nvcc sgemm.cu -o sgemm.exe -arch=compute_61 -code=sm_61 -lcublas --ptxas-options=-v -maxrregcount=128
+# nvcc sgemm.cu -o sgemm.exe -arch=compute_61 -code=sm_61 -lcublas --ptxas-options=-v -maxrregcount=128
+	nvcc sgemm.cu -o sgemm.exe -lcublas --ptxas-options=-v -maxrregcount=128
 
 run:
 	sgemm.exe

--- a/sgemm.cu
+++ b/sgemm.cu
@@ -239,10 +239,14 @@ __global__ void mySgemmV3Aligned(
         FLOAT4(s_b[0][load_b_smem_k][load_b_smem_n]) = FLOAT4(r_load_b[0]);
     }
 
+    __syncthreads();
+    int smem_sel;
+    int smem_sel_next;
+
     for (int bk = 1; bk < (K + BK - 1) / BK; bk++) {
 
-        int smem_sel = (bk - 1) & 1;
-        int smem_sel_next = bk & 1;
+        smem_sel = (bk - 1) & 1;
+        smem_sel_next = bk & 1;
 
         int load_a_gmem_k = bk * BK + load_a_smem_k;
         int load_a_gmem_addr = OFFSET(load_a_gmem_m, load_a_gmem_k, K);
@@ -278,10 +282,10 @@ __global__ void mySgemmV3Aligned(
 
     #pragma unroll
     for (int tk = 0; tk < BK; tk++) {
-        FLOAT4(r_comp_a[0]) = FLOAT4(s_a[1][tk][ty * TM / 2         ]);
-        FLOAT4(r_comp_a[4]) = FLOAT4(s_a[1][tk][ty * TM / 2 + BM / 2]);
-        FLOAT4(r_comp_b[0]) = FLOAT4(s_b[1][tk][tx * TN / 2         ]);
-        FLOAT4(r_comp_b[4]) = FLOAT4(s_b[1][tk][tx * TN / 2 + BN / 2]);
+        FLOAT4(r_comp_a[0]) = FLOAT4(s_a[smem_sel_next][tk][ty * TM / 2         ]);
+        FLOAT4(r_comp_a[4]) = FLOAT4(s_a[smem_sel_next][tk][ty * TM / 2 + BM / 2]);
+        FLOAT4(r_comp_b[0]) = FLOAT4(s_b[smem_sel_next][tk][tx * TN / 2         ]);
+        FLOAT4(r_comp_b[4]) = FLOAT4(s_b[smem_sel_next][tk][tx * TN / 2 + BN / 2]);
 
         #pragma unroll
         for (int tm = 0; tm < TM; tm++) {


### PR DESCRIPTION
1. If not add `sync()` in proper position in mySgemmV3Aligned, the max error will be very large.
    before add `sync()` : ![image](https://github.com/user-attachments/assets/d5031e73-12e0-4f76-8c01-48eb21da9d75)
    after add `sync()`: ![image](https://github.com/user-attachments/assets/4f10b811-ed67-475f-9ce2-23a9e52befc2)


2. The kernel launch failed because of incompatible architecture, so I get rid of relative arguments when compile.